### PR TITLE
v3.2.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install SDKMAN! and tools
         if: runner.os != 'Windows'
@@ -37,7 +37,7 @@ jobs:
     runs-on: macos-13
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install SDKMAN! and tools
         if: runner.os != 'Windows'
@@ -59,7 +59,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Java, Maven, and Scala
         if: runner.os == 'Windows'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,14 +56,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Cache SDKMAN! installations
-        uses: actions/cache@v3
-        with:
-          path: ~/.sdkman
-          key: ${{ runner.os }}-sdkman
-          restore-keys: |
-            ${{ runner.os }}-sdkman-
-
       - name: Install SDKMAN! and tools
         if: runner.os != 'Windows'
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,109 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - devel
+  pull_request:
+    branches:
+      - master
+      - devel
+
+jobs:
+  build-ubuntu:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ github.sha }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-${{ github.sha }}-
+            ${{ runner.os }}-maven-
+
+      - name: Cache SDKMAN! installations
+        uses: actions/cache@v3
+        with:
+          path: ~/.sdkman
+          key: ${{ runner.os }}-sdkman
+          restore-keys: |
+            ${{ runner.os }}-sdkman-
+
+      - name: Install SDKMAN! and tools
+        if: runner.os != 'Windows'
+        run: |
+          if [ ! -f "$HOME/.sdkman/bin/sdkman-init.sh" ]; then
+            curl -s "https://get.sdkman.io" | bash
+          fi
+          source "$HOME/.sdkman/bin/sdkman-init.sh"
+          sdk install java 21.0.3-tem || true
+          sdk install maven 3.9.8 || true
+          sdk install scala 2.12.19 || true
+
+      - name: Build and Package with Maven
+        run: |
+          source "$HOME/.sdkman/bin/sdkman-init.sh"
+          mvn clean package
+
+  build-host-macos:
+    runs-on: macos-13
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Cache SDKMAN! installations
+        uses: actions/cache@v3
+        with:
+          path: ~/.sdkman
+          key: ${{ runner.os }}-sdkman
+          restore-keys: |
+            ${{ runner.os }}-sdkman-
+
+      - name: Install SDKMAN! and tools
+        if: runner.os != 'Windows'
+        run: |
+          if [ ! -f "$HOME/.sdkman/bin/sdkman-init.sh" ]; then
+            curl -s "https://get.sdkman.io" | bash
+          fi
+          source "$HOME/.sdkman/bin/sdkman-init.sh"
+          sdk install java 21.0.3-tem || true
+          sdk install maven 3.9.8 || true
+          sdk install scala 2.12.19 || true
+
+      - name: Build and Package with Maven
+        run: |
+          source "$HOME/.sdkman/bin/sdkman-init.sh"
+          mvn clean package
+
+  build-host-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install Java, Maven, and Scala
+        if: runner.os == 'Windows'
+        run: |
+          if (-not (Get-Command "java" -ErrorAction SilentlyContinue)) {
+            winget install EclipseAdoptium.Temurin.21.JDK
+          }
+          if (-not (Get-Command "mvn" -ErrorAction SilentlyContinue)) {
+            Invoke-WebRequest -Uri https://dlcdn.apache.org/maven/maven-3/3.9.8/binaries/apache-maven-3.9.8-bin.zip -OutFile apache-maven-3.9.8-bin.zip
+            Expand-Archive -Path apache-maven-3.9.8-bin.zip -DestinationPath $env:TEMP\apache-maven-3.9.8
+            $env:Path += ";$env:TEMP\apache-maven-3.9.8\bin"
+            [Environment]::SetEnvironmentVariable('Path', $env:Path, [System.EnvironmentVariableTarget]::Machine)
+          }
+          if (-not (Get-Command "scala" -ErrorAction SilentlyContinue)) {
+            Invoke-WebRequest -Uri https://downloads.lightbend.com/scala/2.12.19/scala-2.12.19.msi -OutFile scala-2.12.19.msi
+            Start-Process msiexec.exe -ArgumentList '/i', 'scala-2.12.19.msi', '/quiet', '/norestart' -Wait
+            $env:Path += ';C:\Program Files (x86)\scala\bin'
+            [Environment]::SetEnvironmentVariable('Path', $env:Path, [System.EnvironmentVariableTarget]::Machine)
+          }
+
+      - name: Build and Package with Maven
+        run: mvn clean package

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,23 +17,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Cache Maven dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ github.sha }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-${{ github.sha }}-
-            ${{ runner.os }}-maven-
-
-      - name: Cache SDKMAN! installations
-        uses: actions/cache@v3
-        with:
-          path: ~/.sdkman
-          key: ${{ runner.os }}-sdkman
-          restore-keys: |
-            ${{ runner.os }}-sdkman-
-
       - name: Install SDKMAN! and tools
         if: runner.os != 'Windows'
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 target
 GreetBot
 .DS_Store
-.vscode/settings.json
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 target
 GreetBot
 .DS_Store
+.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -148,20 +148,20 @@ Even though this bot does not do anything malicious, some servers may not like a
 
 ## Tested OS's
 
-#### This project succesfully compiled and ran on the following Operating Systems (bare-metal, no VM's used)
+#### This project has been manually compiled and run on the following Operating Systems (bare-metal, no VM's/Containers)
 
 - **MacOS**
 
-  - **MacOS Ventura** 13.6.7 (13" Early '15 MacBook Air with OpenCore Legacy Patcher)
-    - [SDKMAN!](https://sdkman.io/) one-line install from their site (same across all systems)
+  - **MacOS Ventura** 13.6.7 (13" Early '15 MacBook Air, Intel, OpenCore Legacy Patcher)
+    - [SDKMAN!](https://sdkman.io/) one-line install from their site (MacOS/Linux only)
     - Scala (2.12.19) installed with SDKMAN!
 
 - **Linux**
 
   - **Arch** (rolling, x86_64, Linux 6.6.37-1-lts)
-    - Java (21.0.3-tem), Scala (2.12.19) and Maven (3.9.8) installed with SDKMAN!
+    - Java (21.0.3-tem), Scala (2.12.19) and Maven (3.9.8) installed with [SDKMAN!](https://sdkman.io/)
   - **Mint** Virginia 21.3 (x86_64, Linux 5.15.0-113-generic)
-    - Scala (2.12.19) and Java (21.0.3-tem) installed with SDKMAN!
+    - Scala (2.12.19) and Java (21.0.3-tem) installed with [SDKMAN!](https://sdkman.io/)
     - Maven from the `apt` repository
 
 - **Windows**

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ Even though this bot does not do anything malicious, some servers may not like a
 
    - You may need to restart your terminal for the install/upgrade to take effect.
 
-3. Run `mvn clean package` which will produce a file in the target folder called `ascensionchat-3.1.1.zip`
-4. Unzip `ascensionchat-3.1.1.zip`, edit the configuration file, and run `run.bat` for Windows or `run.sh` for Linux/MacOS. (Edit the name of the config file in `run.*` if you supply your own config)
+3. Run `mvn clean package` which will produce a file in the target folder called `ascensionchat-3.1.2.zip`
+4. Unzip `ascensionchat-3.1.2.zip`, edit the configuration file, and run `run.bat` for Windows or `run.sh` for Linux/MacOS. (Edit the name of the config file in `run.*` if you supply your own config)
    - If no config file is supplied, the bot will try to use `ascensionchat.conf`
 
 ## Updating

--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ Even though this bot does not do anything malicious, some servers may not like a
 
 ![guild-chat-construct](https://raw.githubusercontent.com/fjaros/wowchat/master/images/example2.png)
 
-## Setup & Prerequisites
+## Setup Discord Bot
 
 1. Create a Discord Bot on your Discord account:
+
    - Go to <https://discordapp.com/developers/applications/>
    - Sign into your Discord account if necessary, and click `Create an application`
    - Change the application name to something meaningful like "WoW Chat"
@@ -53,7 +54,16 @@ Even though this bot does not do anything malicious, some servers may not like a
    - Disable the `Public Bot` option
    - Enable `PRESENCE INTENT`, `SERVER MEMBERS INTENT` and `MESSAGE CONTENT INTENT` under `Privileged Gateway Intents`. **This is important! Without it, your bot will not work!**
    - Underneath where it says `TOKEN`, click `Copy`. _(If you can't see a copy option, click reset then copy)_ This is what Ascension Chat will use to log into Discord.
-2. Configure AscensionChat by opening `ascensionchat.conf` in your text editor of choice. You can also create your own file using the supplied `ascensionchat.conf` as a template.
+
+2. Invite your bot to Discord:
+   - Go back to <https://discordapp.com/developers/applications/> and click your new Bot application.
+   - In the browser, enter: <https://discordapp.com/oauth2/authorize?client_id=CLIENT_ID&scope=bot>
+     - Replace **`CLIENT_ID`** (the one in CAPS) in the URL with the token from the Discord applications page earlier.
+   - Assign the bot the necessary Discord roles/permissions to view/enter your desired channels.
+
+## Configure ascensionchat.conf
+
+1. Configure AscensionChat by opening `ascensionchat.conf` in your preferred text editor. You can also create your own file using the supplied `ascensionchat.conf` as a template.
 
    - **Discord** section:
      - `token`: Paste the `Bot token` you copied above.
@@ -99,13 +109,7 @@ Even though this bot does not do anything malicious, some servers may not like a
      - `patterns`: List of Java Regex match patterns. If the incoming message matches any one of the patterns and filters are enabled, it will be ignored.
        - When ignored, the message will not be relayed; however, it will be logged into the bot's command line output prepended with the word FILTERED.
 
-3. Invite your bot to Discord:
-   - Go back to <https://discordapp.com/developers/applications/> and click your new Bot application.
-   - In the browser, enter: <https://discordapp.com/oauth2/authorize?client_id=CLIENT_ID&scope=bot>
-     - Replace **`CLIENT_ID`** (the one in CAPS) in the URL with the token from the Discord applications page earlier.
-   - Assign the bot the necessary Discord roles/permissions to view/enter your desired channels.
-
-## Run
+## Running AscensionChat
 
 1. Download the [**latest**](https://github.com/NotYourAverageGamer/AscensionChat/releases/latest) ready-made binary from the GitHub [releases](https://github.com/NotYourAverageGamer/AscensionChat/releases)
 

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ Even though this bot does not do anything malicious, some servers may not like a
 
    - You may need to restart your terminal for the install/upgrade to take effect.
 
-3. Run `mvn clean package` which will produce a file in the target folder called `ascensionchat-3.1.2.zip`
-4. Unzip `ascensionchat-3.1.2.zip`, edit the configuration file, and run `run.bat` for Windows or `run.sh` for Linux/MacOS. (Edit the name of the config file in `run.*` if you supply your own config)
+3. Run `mvn clean package` which will produce a file in the target folder called `ascensionchat-3.2.0.zip`
+4. Unzip `ascensionchat-3.2.0.zip`, edit the configuration file, and run `run.bat` for Windows or `run.sh` for Linux/MacOS. (Edit the name of the config file in `run.*` if you supply your own config)
    - If no config file is supplied, the bot will try to use `ascensionchat.conf`
 
 ## Updating

--- a/README.md
+++ b/README.md
@@ -124,10 +124,10 @@ Even though this bot does not do anything malicious, some servers may not like a
    - **On Windows**: Edit `ascensionchat.conf` as above and run `run.bat`
    - **On Mac/Linux**: Edit `ascensionchat.conf` as above and run `run.sh`
 
-**OR** to compile yourself:
+## Compiling AscensionChat from source
 
 1. WoW Chat/AscensionChat is written in Scala and compiles to a Java executable using [**Maven**](https://maven.apache.org).
-2. It requires **Java JDK 1.8+** _(works for me with 17 & 21)_ and [**Scala 2.12.19**](https://www.scala-lang.org/download/2.12.19.html).
+2. It requires **Java JDK 1.8+** and [**Scala 2.12.19**](https://www.scala-lang.org/download/2.12.19.html).
 
    - Check the version of your Java installation with
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Even though this bot does not do anything malicious, some servers may not like a
 ## Compiling AscensionChat from source
 
 1. WoW Chat/AscensionChat is written in Scala and compiles to a Java executable using [**Maven**](https://maven.apache.org).
-2. It requires **Java JDK 1.8+** and [**Scala 2.12.19**](https://www.scala-lang.org/download/2.12.19.html).
+2. It requires **Java JDK 21+** and [**Scala 2.12.19**](https://www.scala-lang.org/download/2.12.19.html).
 
    - Check the version of your Java installation with
 

--- a/README.md
+++ b/README.md
@@ -145,3 +145,28 @@ Even though this bot does not do anything malicious, some servers may not like a
 
 - Download the [**latest**](https://github.com/NotYourAverageGamer/AscensionChat/releases/latest) `ascensionchat.jar` and replace the one in your current `ascensionchat` folder. Alternatively, download the [**latest**](https://github.com/NotYourAverageGamer/AscensionChat/releases/latest) `ascensionchat.zip` file; but be careful not to replace your `ascensionchat.conf`!
   - Before updating your `ascension.conf` file, make sure to save a copy of your current `.conf` file. This will allow you to easily transfer your login details to the new config, making the update process smoother.
+
+## Tested OS's
+
+#### This project succesfully compiled and ran on the following Operating Systems (bare-metal, no VM's used)
+
+- **MacOS**
+
+  - **MacOS Ventura** 13.6.7 (13" Early '15 MacBook Air with OpenCore Legacy Patcher)
+    - [SDKMAN!](https://sdkman.io/) one-line install from their site (same across all systems)
+    - Scala (2.12.19) installed with SDKMAN!
+
+- **Linux**
+
+  - **Arch** (rolling, x86_64, Linux 6.6.37-1-lts)
+    - Java (21.0.3-tem), Scala (2.12.19) and Maven (3.9.8) installed with SDKMAN!
+  - **Mint** Virginia 21.3 (x86_64, Linux 5.15.0-113-generic)
+    - Scala (2.12.19) and Java (21.0.3-tem) installed with SDKMAN!
+    - Maven from the `apt` repository
+
+- **Windows**
+
+  - **Windows 10 Pro** (22H2, 19045.4529)
+    - You will want to use `Windows Terminal` (_which you might not have by default_), because the default `Windows Console Host` does not support the ANSI Escape Sequences used in this project. This results in the Escape Codes showing in the terminal and no colour, making terminal output harder to read. Fortunately, this is pretty straightforward to setup. See [**HERE**](https://learn.microsoft.com/en-us/windows/terminal/install) for steps to setup/install.
+  - **Windows 11 Pro** (23H2, 22631.3737)
+  - **WSL - Ubuntu 22.04** (on Win11-Pro)

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ascensionchat</groupId>
     <artifactId>ascensionchat</artifactId>
-    <version>3.1.2</version>
+    <version>3.2.0</version>
 
     <properties>
         <java.version>1.8</java.version>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>4.4.0_352</version>
+            <version>5.0.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>club.minnced</groupId>
@@ -125,6 +125,7 @@
                                 <exclude>META-INF/*.SF</exclude>
                                 <exclude>META-INF/*.DSA</exclude>
                                 <exclude>META-INF/*.RSA</exclude>
+                                <exclude>**/module-info.class</exclude>
                                 <exclude>logback.xml</exclude>
                                 <exclude>*.conf</exclude>
                             </excludes>
@@ -159,14 +160,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-resources-plugin</artifactId>
+              <version>3.3.1</version>
+              <configuration>
+                <propertiesEncoding>UTF-8</propertiesEncoding>
+              </configuration>
+            </plugin>
         </plugins>
     </build>
-
-    <repositories>
-        <repository>
-            <id>dv8tion</id>
-            <name>m2-dv8tion</name>
-            <url>https://m2.dv8tion.net/releases</url>
-        </repository>
-    </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ascensionchat</groupId>
     <artifactId>ascensionchat</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2</version>
 
     <properties>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>3.2.0</version>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>21</java.version>
         <scala.version.major>2.12</scala.version.major>
         <scala.version.minor>19</scala.version.minor>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.110.Final</version>
+            <version>4.1.111.Final</version>
         </dependency>
 
         <dependency>
@@ -78,7 +78,7 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.3.3</version>
                 <executions>
                     <execution>
                         <id>scala-compile</id>
@@ -107,7 +107,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/src/main/resources/pre_cata_areas.csv
+++ b/src/main/resources/pre_cata_areas.csv
@@ -2263,6 +2263,7 @@
 4688,claytonio test area
 4692,Quel'Delar's Rest
 4710,Isle of Conquest
+4717,Unused Monastery
 4722,Trial of the Crusader
 4723,Trial of the Champion
 4739,Runeweaver Square
@@ -2304,4 +2305,182 @@
 4906,The Shadow Throne
 4908,The Hidden Passage
 4910,Frostmourne
+4926,Blackrock Caverns
 4987,The Ruby Sanctum
+4990,The Twisting Nether
+4999,Twisting Nether
+5000,FFA BG (Test)
+5001,Demon's Tears
+5002,Sty'La
+5003,Open World
+5004,Twisting Nether
+5005,Demon's Tears
+5006,Sty'La
+5031,Twin Peaks
+5680,Wildhammer Flag Room
+5681,Dragonmaw Flag Room
+5775,Dragonmaw Stronghold
+5776,Wildhammer Stronghold
+6001,Icecrown
+6002,The North Sea
+6003,Valkyrion
+6004,Temple of Storms
+6005,Nidavelir
+6006,Narvir's Cradle
+6007,Snowdrift Plains
+6008,Ulduar
+6009,The Shadow Vault
+6010,Bouldercrag's Refuge
+6011,The Blighted Pool
+6012,The Bombardment
+6013,Aldur'thar: The Desolation Gate
+6014,Ironwall Rampart
+6015,Sindragosa's Fall
+6016,The Valley of Lost Hope
+6017,The Valley of Fallen Heroes
+6018,Temple of Wisdom
+6019,Silent Vigil
+6020,First Legion Forward Camp
+6021,Argent Tournament Grounds
+6022,The Ring of Champions
+6023,The Aspirants' Ring
+6024,The Argent Valiants' Ring
+6025,The Alliance Valiants' Ring
+6026,The Horde Valiants' Ring
+6027,Quel'Delar's Rest
+6028,Hrothgar's Landing
+6029,Deathspeaker's Watch
+6030,The Sea Reaver's Run
+6031,Argent Pavilion
+6032,Silver Covenant Pavilion
+6033,Sunreaver Pavilion
+6051,The Temple of Kotmogu
+6060,Temple of Kotmogu
+6061,The Temple of Kotmogu
+6136,The Temple of Kotmogu
+6137,Guardian's Hall
+6138,Spark of Creator
+6732,The Tiger's Peak
+7000,Lordaeron
+7001,Trade Square
+7002,Central Square
+7003,King's Garden
+7004,Cathedral Park
+7005,War Quarter
+7006,Darrowmere Forest
+7007,Instwood
+7008,Noran Manor
+7009,Akghelm
+7010,Hidden Valley
+7011,Noran Mine
+7012,Haunted Valley
+7107,Hillsbrad Foothills
+8442,Amphitheater of Anguish
+8443,The Inventor's Library
+8456,Black Rook Hold Arena
+8457,Tol'Viron Arena
+8458,Ashamane's Fall
+8462,Baradin Hold Arena
+8463,Obelisk of the Stars
+10000,Underworld
+10001,Underworld
+10002,Astaroth
+10003,Aspects Trials
+10004,Throne of Norgannon
+10005,Halls of Valor
+10006,Black Dev Map
+10007,Spell Dev Map
+10008,A Wrinkle in Time
+10009,Harvest Island
+10010,Blacklineage
+10011,Stormwind Sewer
+10012,Orgrimmar Depths
+10013,Mish Faramos
+10014,Dungeon Dev Map
+10015,Raid Dev Map
+10016,Mini Games
+10017,Housing Human
+10018,Newnerub
+10019,Azzar Island
+10020,Ocean Battle
+10021,To Northrend
+10022,Dreamlike Dream
+10023,Frozen Reach
+10024,Frozen Sepulcher
+10025,Kau'ki Village
+10026,Plains of Echoes
+10027,Coliseum of Past Echoes
+10028,Ahn'kahet: The Old Kingdom
+10029,Imperial Arena of Thakraj
+10030,Ocean's Sword
+10031,Gronn's Spine
+10032,Maldraxxus
+10033,Maldraxxus Coliseum
+10034,Warsong Gulch
+10035,Warsong Lumber Mill
+10036,Silverwing Hold
+10037,Silverwing Flag Room
+10038,Blade's Edge Mountains
+10039,Blade's Edge Arena
+10040,Nagrand
+10041,Nagrand Arena
+10042,Warsong Flag Room
+10043,Arathi Basin
+10044,Trollbane Hall
+10045,Defiler's Den
+10046,Farm
+10047,Blacksmith
+10048,Lumber Mill
+10049,Gold Mine
+10050,Stables
+10051,The Twisting Nether
+10052,Kil'jaeden's Ship Arena
+10053,Val'sharah
+10054,Ashamane's Fall
+10055,Uldum
+10056,Tol'Viron Arena
+10057,Black Rook Hold
+10058,Black Rook Hold Arena
+10059,The Robodrome
+11211,Ascension
+11220,Stormwind City
+11221,Orgrimmar
+11222,Leaving Stormwind
+11224,Leaving Orgrimmar
+11226,Stormwind Harbour
+11228,Valley of Trials
+11231,Camp Narache
+11234,Red Cloud Mesa
+11235,Kodo Rock
+11237,Brambleblade Ravine
+11238,Shadowglen
+11241,Aldrassil
+11242,Northshire Valley
+11244,Northshire Vineyards
+11246,Echo Ridge Mine
+11247,Coldridge Valley
+11248,Coldridge Pass
+11249,Deathknell
+11250,Sunstrider Isle
+11253,Shrine of Dath'Remar
+11254,Ammen Vale
+11255,Crash Site
+11256,The Sacred Grove
+11257,Ammen Fields
+11258,Silverline Lake
+11259,Nestlewood Thicket
+11260,Nestlewood Hills
+11261,Shadow Ridge
+11425,The Altar of Eternity
+11426,Lumber Mill
+11427,Temple of Eternity
+11428,Isle of the Forgotten God
+11429,The Grim Marsh
+11430,Forgotten Mine
+11431,Rocky Lake
+11432,Mountain Trail
+11433,Stonetalon Highlands
+11434,Plain of Gold
+11435,Iskirr Village
+11437,The Forgotten Isle
+11439,Eonar's Cradle

--- a/src/main/resources/run.bat
+++ b/src/main/resources/run.bat
@@ -1,3 +1,4 @@
-chcp 65001
+@echo off
+chcp 65001 > NUL
 java -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -Dlogback.configurationFile=logback.xml -jar ascensionchat.jar ascensionchat.conf
 pause

--- a/src/main/scala/wowchat/WoWChat.scala
+++ b/src/main/scala/wowchat/WoWChat.scala
@@ -21,6 +21,7 @@ object WoWChat extends StrictLogging {
     logger.info(s"""${Ansi.BOLD}
 
 
+
 ${Ansi.GREEN}  .d8b.  .d8888.  .o88b. d88888b d8b   db .d8888. d888888b .d88b.  d8b   db  .o88b. db   db  .d8b.  d888888b
 ${Ansi.GREEN} d8' `8b 88'  YP d8P  Y8 88'     888o  88 88'  YP   `88'  .8P  Y8. 888o  88 d8P  Y8 88   88 d8' `8b `~~88~~'
 ${Ansi.GREEN} 88ooo88 `8bo.   8P      88ooooo 88V8o 88 `8bo.      88   88    88 88V8o 88 8P      88ooo88 88ooo88    88   
@@ -85,7 +86,7 @@ ${Ansi.GREEN} YP   YP `8888Y'  `Y88P' Y88888P VP   V8P `8888Y' Y888888P `Y88P'  
       /** Initiates reconnection to the game server. */
       def doReconnect: Unit = {
         Global.group.shutdownGracefully()
-        Global.discord.changeRealmStatus(s"${Ansi.BCYAN}Connecting...${Ansi.CLR}")
+        Global.discord.changeRealmStatus(s"Connecting...")
         val delay = reconnectDelay.getNext
         logger.info(s"${Ansi.RED}Disconnected from server!${Ansi.CLR} Reconnecting in $delay seconds...")
 

--- a/src/main/scala/wowchat/WoWChat.scala
+++ b/src/main/scala/wowchat/WoWChat.scala
@@ -86,7 +86,7 @@ ${Ansi.GREEN} YP   YP `8888Y'  `Y88P' Y88888P VP   V8P `8888Y' Y888888P `Y88P'  
       /** Initiates reconnection to the game server. */
       def doReconnect: Unit = {
         Global.group.shutdownGracefully()
-        Global.discord.changeRealmStatus(s"Connecting...")
+        Global.discord.changeRealmStatus("Connecting...")
         val delay = reconnectDelay.getNext
         logger.info(s"${Ansi.RED}Disconnected from server!${Ansi.CLR} Reconnecting in $delay seconds...")
 

--- a/src/main/scala/wowchat/commands/CommandHandler.scala
+++ b/src/main/scala/wowchat/commands/CommandHandler.scala
@@ -1,7 +1,7 @@
 package wowchat.commands
 
 import com.typesafe.scalalogging.StrictLogging
-import net.dv8tion.jda.api.entities.MessageChannel
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
 import wowchat.common.Global
 import wowchat.game.{GamePackets, GameResources, GuildInfo, GuildMember}
 

--- a/src/main/scala/wowchat/common/Global.scala
+++ b/src/main/scala/wowchat/common/Global.scala
@@ -4,7 +4,7 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 import io.netty.channel.EventLoopGroup
-import net.dv8tion.jda.api.entities.TextChannel
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import wowchat.discord.Discord
 import wowchat.game.GameCommandHandler
 

--- a/src/main/scala/wowchat/discord/Discord.scala
+++ b/src/main/scala/wowchat/discord/Discord.scala
@@ -8,9 +8,11 @@ import com.typesafe.scalalogging.StrictLogging
 import com.vdurmont.emoji.EmojiParser
 import net.dv8tion.jda.api.JDABuilder
 import net.dv8tion.jda.api.JDA.Status
-import net.dv8tion.jda.api.entities.{Activity, ChannelType, MessageType}
+import net.dv8tion.jda.api.entities.channel.ChannelType
+import net.dv8tion.jda.api.entities.{Activity, MessageType}
 import net.dv8tion.jda.api.entities.Activity.ActivityType
-import net.dv8tion.jda.api.events.{ShutdownEvent, StatusChangeEvent}
+import net.dv8tion.jda.api.events.StatusChangeEvent
+import net.dv8tion.jda.api.events.session.ShutdownEvent
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 import net.dv8tion.jda.api.requests.{CloseCode, GatewayIntent}
@@ -32,7 +34,7 @@ class Discord(discordConnectionCallback: CommonConnectionCallback) extends Liste
     * The JDA instance for interfacing with the Discord API.
     */
   private val jda = JDABuilder
-    .createDefault(Global.config.discord.token, GatewayIntent.GUILD_MESSAGES, GatewayIntent.GUILD_MEMBERS, GatewayIntent.GUILD_PRESENCES, GatewayIntent.GUILD_EMOJIS)
+    .createDefault(Global.config.discord.token, GatewayIntent.GUILD_MESSAGES, GatewayIntent.GUILD_MEMBERS, GatewayIntent.GUILD_PRESENCES, GatewayIntent.GUILD_EMOJIS_AND_STICKERS, GatewayIntent.SCHEDULED_EVENTS, GatewayIntent.MESSAGE_CONTENT)
     .setMemberCachePolicy(MemberCachePolicy.ALL)
     .disableCache(CacheFlag.VOICE_STATE)
     .addEventListeners(this)
@@ -76,7 +78,7 @@ class Discord(discordConnectionCallback: CommonConnectionCallback) extends Liste
     * @param message The message associated with the realm status.
     */
   def changeRealmStatus(message: String): Unit = {
-    changeStatus(ActivityType.DEFAULT, message)
+    changeStatus(ActivityType.CUSTOM_STATUS, message)
   }
 
   /**

--- a/src/main/scala/wowchat/discord/MessageResolver.scala
+++ b/src/main/scala/wowchat/discord/MessageResolver.scala
@@ -1,7 +1,7 @@
 package wowchat.discord
 
 import net.dv8tion.jda.api.JDA
-import net.dv8tion.jda.api.entities.TextChannel
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import wowchat.common.{WowChatConfig, WowExpansion}
 import wowchat.game.GameResources
 
@@ -208,7 +208,7 @@ class MessageResolver(jda: JDA) {
     val regex = "(?<=:).*?(?=:)".r
 
     // Could implement caching here later
-    val emojiMap = jda.getEmotes.asScala.map(emote => {
+    val emojiMap = jda.getEmojis.asScala.map(emote => {
       emote.getName.toLowerCase -> emote.getId
     }).toMap
 


### PR DESCRIPTION
## Fixes #11 

- Added [**org.apache.maven.plugins:maven-resources-plugin**](https://github.com/apache/maven-resources-plugin) `3.3.1`
- Updated [**io.netty:netty-all**](https://github.com/netty/netty) to `4.1.111`
- Updated [**net.alchim31.maven:scala-maven-plugin**](https://github.com/davidB/scala-maven-plugin) to `3.3.3`
- Updated [**org.apache.maven.plugins:maven-shade-plugin**](https://github.com/apache/maven-shade-plugin) to `3.2.1`
- Updated [**net.dv8tion:JDA**](https://github.com/discord-jda/JDA) to `5.0.0`

### Other changes

- Added `.github/workflows/main.yml` for [act](https://github.com/nektos/act)
- Bump Java version to `21`
- Add missing `pre_cata_areas` (credit: xan-asc/https://github.com/xanthics/AscensionChat/commit/62af82521dd7de85f04c8049b4d8c99ec0400078
- Split up Discord Bot Creation and AscensionChat Setup in `README.md`
- Added `Tested OS's` to `README.md`